### PR TITLE
Fix sport modal default selection handling

### DIFF
--- a/src/components/SportTile.tsx
+++ b/src/components/SportTile.tsx
@@ -70,7 +70,7 @@ function SportTile() {
   );
 
   const openSportManager = (sport?: SportKey) => {
-    const fallbackSport = activeSportOptions[0]?.key ?? 'hiit';
+    const fallbackSport = sport ?? activeSportOptions[0]?.key ?? 'hiit';
     setSelectedSport(fallbackSport);
     setShowModal(true);
   };


### PR DESCRIPTION
## Summary
- ensure the sport manager modal preserves the sport that triggered it

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e6121af3588333a55089485a1c77a4