### PR TITLE
Remove pushup display from training load tile

### DIFF
--- a/src/__tests__/TrainingLoadTile.test.tsx
+++ b/src/__tests__/TrainingLoadTile.test.tsx
@@ -80,7 +80,7 @@ afterEach(async () => {
     expect(screen.getByText('Training Load')).toBeInTheDocument();
     expect(screen.getByText('300')).toBeInTheDocument();
     expect(screen.getByTestId('training-load-sleep-value').textContent).toContain('8');
-    expect(screen.getByTestId('training-load-pushups-value').textContent).toContain('50');
+    expect(screen.queryByTestId('training-load-pushups-value')).toBeNull();
   });
 
   it('shows fallback state when no data is present', async () => {

--- a/src/components/TrainingLoadTile.tsx
+++ b/src/components/TrainingLoadTile.tsx
@@ -103,7 +103,6 @@ function TrainingLoadTile() {
     : '—';
   const sleepDisplay = recoveryTracked ? `${formatScore(sleepQuality)}/10` : '—';
   const recoveryDisplay = recoveryTracked ? `${formatScore(recoveryScore)}/10` : '—';
-  const pushupDisplay = pushupsTracked ? `${pushupsTotal}` : '—';
 
   return (
     <div
@@ -174,16 +173,6 @@ function TrainingLoadTile() {
             {workoutsDisplay}
           </div>
         </div>
-      </div>
-
-      <div className="mt-3 rounded-xl bg-white/5 px-3 py-2 text-[11px] text-gray-100/80">
-        <span className="text-gray-100/60">{t('dashboard.trainingLoadPushups')}:</span>{' '}
-        <span
-          className="font-semibold text-gray-50 dark:text-white"
-          data-testid="training-load-pushups-value"
-        >
-          {pushupDisplay}
-        </span>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- remove the pushup summary row from the training load tile while keeping pushups in the computation
- adjust the training load tile test to match the updated UI

## Testing
- npm test -- --runTestsByPath src/__tests__/TrainingLoadTile.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68e61e39e39c8333936f7ad4727186a9