### PR TITLE
Fix lint issues in training load tile and test utils

### DIFF
--- a/src/components/TrainingLoadTile.tsx
+++ b/src/components/TrainingLoadTile.tsx
@@ -160,8 +160,6 @@ function TrainingLoadTile() {
     : '—';
   const sleepDisplay = recoveryTracked ? `${formatScore(sleepQuality)}/10` : '—';
   const recoveryDisplay = recoveryTracked ? `${formatScore(recoveryScore)}/10` : '—';
-  const pushupDisplay = pushupsTracked ? `${pushupsDisplayTotal}` : '—';
-
   return (
     <div
       className={`w-full ${getTileClasses(hasData)} ${designTokens.padding.compact} text-left text-white`}

--- a/test/test-utils.tsx
+++ b/test/test-utils.tsx
@@ -1,21 +1,10 @@
-import { ReactElement, ReactNode } from 'react';
+import type { ReactElement, ReactNode } from 'react';
 import { MemoryRouter, MemoryRouterProps } from 'react-router-dom';
 import { render, RenderOptions } from '@testing-library/react';
 import { ThemeProvider } from '@/contexts/ThemeContext';
 
 interface ProvidersProps {
   children: ReactNode;
-  route?: string;
-  routerProps?: Omit<MemoryRouterProps, 'children'>;
-}
-
-function Providers({ children, route = '/', routerProps }: ProvidersProps) {
-  const initialEntries = routerProps?.initialEntries ?? [route];
-  return (
-    <MemoryRouter {...routerProps} initialEntries={initialEntries}>
-      <ThemeProvider>{children}</ThemeProvider>
-    </MemoryRouter>
-  );
 }
 
 interface CustomRenderOptions extends Omit<RenderOptions, 'wrapper'> {
@@ -27,14 +16,18 @@ export function renderWithProviders(
   ui: ReactElement,
   { route = '/', routerProps, ...options }: CustomRenderOptions = {}
 ) {
+  const initialEntries = routerProps?.initialEntries ?? [route];
+
   return render(ui, {
-    wrapper: ({ children }) => (
-      <Providers route={route} routerProps={routerProps}>
-        {children}
-      </Providers>
-    ),
+    wrapper: function ProvidersWrapper({ children }: ProvidersProps) {
+      return (
+        <MemoryRouter {...routerProps} initialEntries={initialEntries}>
+          <ThemeProvider>{children}</ThemeProvider>
+        </MemoryRouter>
+      );
+    },
     ...options,
   });
 }
 
-export * from '@testing-library/react';
+export { fireEvent, screen, waitFor } from '@testing-library/react';


### PR DESCRIPTION
## Summary
- remove the unused pushup display variable from the training load tile component to satisfy eslint
- simplify the test render helper wrapper and re-export specific testing-library utilities to silence react-refresh warnings

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e6291d6b188333bcb2a5cf27f52508