### PR TITLE
Remove duplicate mapUploadError helper

### DIFF
--- a/src/services/storageService.ts
+++ b/src/services/storageService.ts
@@ -141,12 +141,3 @@ export async function deleteProfilePicture(
   }
 }
 
-function mapUploadError(error: unknown): UploadResult {
-  if (error instanceof FirebaseError) {
-    return { success: false, error: error.code };
-  }
-  if (error instanceof Error) {
-    return { success: false, error: error.message };
-  }
-  return { success: false, error: 'unknown_error' };
-}


### PR DESCRIPTION
## Summary
- remove the duplicate `mapUploadError` helper in the storage service so the Firebase error mapping is defined in a single place

## Testing
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68e632fa9ac88333a8db150a83552fad