### PR TITLE
Handle demo auth fallback for Playwright flows

### DIFF
--- a/src/constants/demo.ts
+++ b/src/constants/demo.ts
@@ -1,0 +1,25 @@
+export const DEMO_MODE_FLAG_KEY = 'winter-arc-demo-mode';
+
+export function markDemoModeActive(): void {
+  try {
+    localStorage.setItem(DEMO_MODE_FLAG_KEY, 'true');
+  } catch {
+    // ignore storage access errors in restricted environments
+  }
+}
+
+export function clearDemoModeMarker(): void {
+  try {
+    localStorage.removeItem(DEMO_MODE_FLAG_KEY);
+  } catch {
+    // ignore storage access errors in restricted environments
+  }
+}
+
+export function isDemoModeActive(): boolean {
+  try {
+    return localStorage.getItem(DEMO_MODE_FLAG_KEY) === 'true';
+  } catch {
+    return false;
+  }
+}

--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -4,6 +4,7 @@ import { doc, getDoc, collection, getDocs, setDoc } from 'firebase/firestore';
 import { auth, db } from '../firebase/config';
 import { useStore } from '../store/useStore';
 import type { User, DailyTracking, Activity } from '../types';
+import { clearDemoModeMarker, isDemoModeActive } from '../constants/demo';
 
 export function useAuth() {
   const setUser = useStore((state) => state.setUser);
@@ -21,6 +22,8 @@ export function useAuth() {
           uid: firebaseUser.uid,
           email: firebaseUser.email,
         });
+
+        clearDemoModeMarker();
 
         try {
           const userDocRef = doc(db, 'users', firebaseUser.uid);
@@ -114,6 +117,11 @@ export function useAuth() {
           setAuthLoading(false);
         }
       } else {
+        if (isDemoModeActive()) {
+          setAuthLoading(false);
+          return;
+        }
+
         setUser(null);
         setIsOnboarded(false);
         setTracking({});

--- a/src/pages/LoginPage.tsx
+++ b/src/pages/LoginPage.tsx
@@ -3,6 +3,7 @@ import { useNavigate } from 'react-router-dom';
 import { signInWithPopup, signInWithRedirect, getRedirectResult } from 'firebase/auth';
 import { auth, googleProvider } from '../firebase/config';
 import { useStore } from '../store/useStore';
+import { markDemoModeActive } from '../constants/demo';
 
 function LoginPage() {
   const navigate = useNavigate();
@@ -128,6 +129,7 @@ function LoginPage() {
 
     setUser(demoUser);
     setIsOnboarded(true);
+    markDemoModeActive();
   };
 
   return (


### PR DESCRIPTION
## Summary
- add shared helpers to persist a demo-mode flag in local storage
- keep the Firebase auth listener from clearing demo sessions so the dashboard loads in tests
- update the demo login button to mark sessions for the new guard

## Testing
- npm run lint
- npm run typecheck
- npm run e2e *(fails: Playwright browsers missing in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e642488ddc83338453dbdf06d69f1a